### PR TITLE
Force protocol-relative URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A simple WordPress SpaceAPI plugin that provides a template tag to display the s
   * Calls SpaceAPI server-side, no JavaScript required.
   * Customizable template tag to display an icon or a text state.
   * Plugin settings page to set the SpaceAPI and output options.
-  * Use SpaceAPI or manually set icons
+  * Setting to use SpaceAPI or manually set icons
+  * Setting to force protocol-relative image-URLs
+  * Widget to display SpaceAPI Status
 
 **To be implemented**
   * Make use of WordPress´ media uploader to upload icons.

--- a/settings.php
+++ b/settings.php
@@ -133,6 +133,15 @@ function wp_spacestatus_use_spaceapi_icons() {
             '<label for="wp_spacestatus_use_spaceapi_icons_manuel">Set icons manuelly<label>';
 }
 
+function wp_spacestatus_force_protocol_relative() {
+
+    $option = get_option_or_default('force_protocol_relative', 'false');
+
+    echo '<input id="wp_spacestatus_force_protocol_relative" name="wp_spacestatus_options[force_protocol_relative]" ' .
+            'type="checkbox" value="true"' . ($option === 'true' ? ' checked="checked"' : '') . ' />' .
+            '<label for="wp_spacestatus_use_spaceapi_icons_spaceapi">replace "http://" by "//" in image URLs.<label><br />';
+}
+
 function wp_spacestatus_icon_closed_url() {
 
     $option = get_option_or_default(
@@ -182,6 +191,7 @@ function plugin_admin_init() {
     add_settings_field('wp_spacestatus_textstatus_closed', 'Text status <em>closed</em>', 'wp_spacestatus_textstatus_closed_string', 'wp_spacestatus', 'wp_spacestatus_appearance_section');
     add_settings_field('wp_spacestatus_textstatus_unknown', 'Text status <em>unknown</em>', 'wp_spacestatus_textstatus_unknown_string', 'wp_spacestatus', 'wp_spacestatus_appearance_section');
     add_settings_field('wp_spacestatus_use_spaceapi_icons', 'Use SpaceAPI icons', 'wp_spacestatus_use_spaceapi_icons', 'wp_spacestatus', 'wp_spacestatus_appearance_section');
+    add_settings_field('wp_spacestatus_force_protocol_relative', 'Force procol-relative URL', 'wp_spacestatus_force_protocol_relative', 'wp_spacestatus', 'wp_spacestatus_appearance_section');
     add_settings_field('wp_spacestatus_icon_open_url', 'Icon <em>open</em>', 'wp_spacestatus_icon_open_url', 'wp_spacestatus', 'wp_spacestatus_appearance_section');
     add_settings_field('wp_spacestatus_icon_closed_url', 'Icon <em>closed</em>', 'wp_spacestatus_icon_closed_url', 'wp_spacestatus', 'wp_spacestatus_appearance_section');
     add_settings_field('wp_spacestatus_icon_unknown_url', 'Icon <em>unknown</em>', 'wp_spacestatus_icon_unknown_url', 'wp_spacestatus', 'wp_spacestatus_appearance_section');
@@ -198,10 +208,11 @@ function plugin_options_validate($input) {
     $newinput['textstatus_unknown_string'] = $input['textstatus_unknown_string']; //FIXME validate
 
     $newinput['use_spaceapi_icons'] = $input['use_spaceapi_icons']; //FIXME validate
+    $newinput['force_protocol_relative'] = $input['force_protocol_relative']; //FIXME validate
     $newinput['icon_open_url']    = $input['icon_open_url']; //FIXME validate
     $newinput['icon_closed_url']  = $input['icon_closed_url']; //FIXME validate
     $newinput['icon_unknown_url'] = $input['icon_unknown_url']; //FIXME validate
-    
+
     $newinput['lastchange_date_format'] = $input['lastchange_date_format']; //FIXME validate
 
     return $newinput;

--- a/settings.php
+++ b/settings.php
@@ -16,6 +16,8 @@
  *
  *  Authors:
  *      Michael Wendland <michael@michiwend.com>
+ *      Peter Grassberger <petertheone@gmail.com>
+ *      Stefan More <dev+github@2904.cc>
  */
 
 require_once('space_api.php');

--- a/wp_spacestatus.php
+++ b/wp_spacestatus.php
@@ -16,6 +16,7 @@
  *
  *  Authors:
  *      Michael Wendland <michael@michiwend.com>
+*
  */
 
 /*
@@ -134,7 +135,9 @@ add_shortcode('space_lastchange', 'lastchange_shortcode');
 
 function spacestatus_head_link() {
     $options  = get_option('wp_spacestatus_options');
-    echo '<link rel="space-api" title="Hackerspace API Endpoint" type="application/json" href="' . $options['api_url_string'] . '"/>'. "\n";
+
+    $url = $options['force_protocol_relative'] === 'true' ? str_replace("http:", "", $options['api_url_string']) : $options['api_url_string'];
+    echo '<link rel="space-api" title="Hackerspace API Endpoint" type="application/json" href="' . $url . '"/>'. "\n";
 }
 
 add_action('wp_head', 'spacestatus_head_link');

--- a/wp_spacestatus.php
+++ b/wp_spacestatus.php
@@ -44,6 +44,10 @@ function icon($status, $src, $options, $sc_attrs) {
     if( $sc_attrs['width'] != '' )  $style = "width: {$sc_attrs['width']}; ";
     if( $sc_attrs['height'] != '' ) $style = $style."height: {$sc_attrs['height']};";
 
+    if($options['force_protocol_relative'] === 'true') {
+        $src = str_replace("http:", "", $src);
+    }
+
     return "<img src=\"$src\" alt=\"$alt\" title=\"$title\" style=\"$style\" class=\"{$sc_attrs['class']}\" id=\"{$sc_attrs['id']}\" />";
 }
 

--- a/wp_spacestatus.php
+++ b/wp_spacestatus.php
@@ -16,7 +16,8 @@
  *
  *  Authors:
  *      Michael Wendland <michael@michiwend.com>
-*
+ *      Peter Grassberger <petertheone@gmail.com>
+ *      Stefan More <dev+github@2904.cc>
  */
 
 /*


### PR DESCRIPTION
Optional setting to force protocol-relative URLs (to images) by replacing "http://" with "//".

Please note: 
- We do not downgrade https URLS to protocol-relative URLs!
- Only activate if the server which is serving your SpaceAPI-images supports HTTP and HTTPS!

Background Infos:
- https://en.wikipedia.org/wiki/Wikipedia:Protocol-relative_URL
